### PR TITLE
bump depedency version to fix compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ libflate = "1.1"
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_json = { version = "1.0", optional = true }
 process-memory = { version = "0.4", optional = true }
-sysinfo = { version = "0.25", optional = true }
+sysinfo = { version = "0.28", optional = true }
 scan_fmt = {version = "0.2", optional = true }
 hyper = { version = "0.14", optional = true, features = ["full"] }
 hyper-rustls = { version = "0.23", optional = true }


### PR DESCRIPTION
building old versions of `ntapi` with newer compilers (I'm using `1.17.0`) fails with `reference to packed field is unaligned`
`ntapi` is a transitive dependency through `sysinfo`